### PR TITLE
fix: dev and prod build failing locally

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -86,7 +86,7 @@ export default {
     plugins: [
       new webpack.DefinePlugin({
         'process.env': {
-          ROUTER_BASE: routerBase,
+          ROUTER_BASE: `"${routerBase}"`,
           PACKAGE_VERSION: `"${version}"`
         }
       })


### PR DESCRIPTION
Simply adding an environment variable like:
```js
ROUTER_BASE: routerBase,
```
Seems to break the *local* build process (but for some reason not the deployment 🤔 )
I changed it to 
```js
ROUTER_BASE: `"${routerBase}"`,
```
And it seems to fix it