### PR TITLE
fix: improve slugify plugin to work cross-browser and handle more cases

### DIFF
--- a/plugins/slugify.js
+++ b/plugins/slugify.js
@@ -4,12 +4,12 @@ const mixin = {
   methods: {
     slugify (text) {
       return text.toString().toLowerCase()
-        .replace(/\s+/g, '-')           // Replace spaces with -
-        .replace(/_/g, '-')           // Replace underscores _ with -
-        .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-        .replace(/\-\-+/g, '-')         // Replace multiple - with single -
-        .replace(/^-+/, '')             // Trim - from start of text
-        .replace(/-+$/, '');            // Trim - from end of text
+        .replace(/\s+/g, '-') // Replace spaces with -
+        .replace(/_/g, '-') // Replace underscores _ with -
+        .replace(/[^\w-]+/g, '') // Remove all non-word chars
+        .replace(/--+/g, '-') // Replace multiple - with single -
+        .replace(/^-+/, '') // Trim - from start of text
+        .replace(/-+$/, '') // Trim - from end of text
     }
   }
 }

--- a/plugins/slugify.js
+++ b/plugins/slugify.js
@@ -2,8 +2,14 @@ import Vue from 'vue'
 
 const mixin = {
   methods: {
-    slugify (string) {
-      return string.replace(/[^a-zA-Z ]/g, '').replaceAll(' ', '-').toLowerCase()
+    slugify (text) {
+      return text.toString().toLowerCase()
+        .replace(/\s+/g, '-')           // Replace spaces with -
+        .replace(/_/g, '-')           // Replace underscores _ with -
+        .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+        .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+        .replace(/^-+/, '')             // Trim - from start of text
+        .replace(/-+$/, '');            // Trim - from end of text
     }
   }
 }


### PR DESCRIPTION
Turns out replaceAll is not supported by all platforms: https://www.designcise.com/web/tutorial/how-to-fix-replaceall-is-not-a-function-javascript-error

I replaced it with a .replace(/\s+/g, '-') and added some more checks, taken from https://gist.github.com/mathewbyrne/1280286